### PR TITLE
Cleanup wasm images before compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build publish run debug
 
 DOCKER_NAME := "cosmwasm/rust-optimizer"
-DOCKER_TAG := 0.8.0
+DOCKER_TAG := 0.8.1
 CODE ?= "/path/to/contract"
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)

--- a/optimize.sh
+++ b/optimize.sh
@@ -12,6 +12,9 @@ echo "Building contract in $(realpath -m "$contractdir")"
 (
   cd "$contractdir"
 
+  # delete all pre-existing wasm files first (otherwise reusing volume for different contracts fails)
+  rm target/wasm32-unknown-unknown/release/*.wasm
+
   # Linker flag "-s" for stripping (https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957)
   # Note that shortcuts from .cargo/config are not available in source code packages from crates.io
   RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown --locked


### PR DESCRIPTION
I ran the contract compile instructions in cosmwasm only to find odd errors about 2nd argument to INFILE. This fixes that issue.

I updated the target of `cosmwasm_cache` to actually be used (before it was writing to the filesystem and leaving root-owned files in my target dir). Different was eg `target=/code/target` => `target=/code/contracts/hackatom/target`. With this changes it now actually made use of the cache.

```bash
docker run --rm -v "$(pwd)":/code \
  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/contracts/hackatom/target \
  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
  cosmwasm/rust-optimizer:0.8.0 ./contracts/hackatom

docker run --rm -v "$(pwd)":/code \
  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/contracts/queue/target \
  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
  cosmwasm/rust-optimizer:0.8.0 ./contracts/queue
```

However, now we have `hackatom.wasm` and `queue.wasm` in the same target dir and this line in `optimize.sh` fails:

```sh
  wasm-opt -Os target/wasm32-unknown-unknown/release/*.wasm -o contract.wasm
```

It requires exactly one file to match the `*.wasm`.

Simple update to to delete all `*.wasm` files in that directory before building. Now it runs fine and also much quicker.