### PR TITLE
Update to Rust 1.45

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM trzeci/emscripten:1.39.8-fastcomp
 
 # Note: I tried slim and had issues compiling wasm-pack, even with --features vendored-openssl
-FROM rust:1.43.1
+FROM rust:1.45.0
 
 # setup rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build publish run debug
 
 DOCKER_NAME := "cosmwasm/rust-optimizer"
-DOCKER_TAG := 0.8.0
+DOCKER_TAG := 0.9.0
 CODE ?= "/path/to/contract"
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)


### PR DESCRIPTION
Tag docker image as 0.9.0.

This is needed to compile 0.10.0-prerelease contracts as the changes for Binary::from need 1.44.1+