### PR TITLE
Find and build all packages individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 0.10.2
+
+- Bump Rust to 1.45.2
+- Build all packages found in the source tree individually. The search root is
+  the first command line argument, defaulting to `.`.
+
+## 0.10.1
+
+## 0.10.0
+
 ## 0.9.0
 
 - Bump Rust to 1.45.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM trzeci/emscripten:1.39.8-fastcomp
 
 # Note: I tried slim and had issues compiling wasm-pack, even with --features vendored-openssl
-FROM rust:1.45.0
+FROM rust:1.45.2
 
 # setup rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build publish run debug
 
 DOCKER_NAME := "cosmwasm/rust-optimizer"
-DOCKER_TAG := 0.10.1
+DOCKER_TAG := 0.10.2
 CODE ?= "/path/to/contract"
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)

--- a/optimize.sh
+++ b/optimize.sh
@@ -4,37 +4,43 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 
 export PATH=$PATH:/root/.cargo/bin
 
-mkdir -p artifacts
-contractdir="$1"
+contracts_root="$1"
 
-# There are two cases here
-# 1. All contracts (or one) are included in the root workspace  (eg. `cosmwasm-template`, `cosmwasm-examples`, `cosmwasm-plus`)
-#    In this case, we pass no argument, just mount the proper directory.
-# 2. Contacts are excluded from the root workspace, but import relative paths from other packages (only `cosmwasm`).
-#    In this case, we mount root workspace and pass in a path `docker run <repo> ./contracts/hackatom`
+# See https://stackoverflow.com/a/23357277/2013738 to understand this find-to-array monster
+contract_dirs=()
+while IFS=  read -r -d $'\0'; do
+  contract_dir=$(dirname "$REPLY")
+  contract_dirs+=("$contract_dir")
+done < <(find "$contracts_root" \( -name target -o -name package -o -name .git \) -type d -prune -false -o -name Cargo.toml -type f -print0)
+echo "Found the following contract dirs: ${contract_dirs[*]}"
 
-# This parameter allows us to mount a folder into docker container's "/code"
-# and build "/code/contracts/mycontract".
-# Note: if contractdir is "." (default in Docker), this ends up as a noop
-echo "Building contract in $(realpath -m "$contractdir")"
-(
-  cd "$contractdir"
+for contract_dir in "${contract_dirs[@]}"; do
+  echo "Building contract in $(realpath -m "$contract_dir")"
+  (
+    cd "$contract_dir"
 
-  # Linker flag "-s" for stripping (https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957)
-  # Note that shortcuts from .cargo/config are not available in source code packages from crates.io
-  RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown --locked
-)
-
-# wasm-optimize on all results
-for wasm in "$contractdir"/target/wasm32-unknown-unknown/release/*.wasm; do
-  name=$(basename "$wasm")
-  echo "Optimizing $name"
-  wasm-opt -Os "$wasm" -o "artifacts/$name"
+    # Linker flag "-s" for stripping (https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957)
+    # Note that shortcuts from .cargo/config are not available in source code packages from crates.io
+    RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown --locked
+  )
 done
+
+mkdir -p artifacts
+artifacts_dir=$(realpath artifacts)
+
+# find the target directories and build results, optimize and write to artifacts
+while IFS= read -r -d '' target_dir; do
+  for wasm in "$target_dir"/release/*.wasm; do
+    echo "Found build result $wasm"
+    name=$(basename "$wasm")
+    wasm-opt -Os "$wasm" -o "$artifacts_dir/$name"
+    echo "Created artifact $name"
+  done
+done <  <(find . -name wasm32-unknown-unknown -type d -print0)
 
 # create hash
 (
-  cd artifacts
+  cd "$artifacts_dir"
   sha256sum -- *.wasm > checksums.txt
 )
 


### PR DESCRIPTION
Closes #21

So, the basic idea is: find all `Cargo.toml`s and run an optimized build in their directories. An optional argument serves as a filtering path.

The verification process for cosmwasm-plus is still not solved because:
1. Running the default command in the repo will build all of `. ./contracts/cw20-base ./contracts/cw20-escrow ./contracts/cw1-whitelist ./contracts/cw1-subkeys ./packages/cw1 ./packages/cw20 ./packages/cw2` in no defined order, such that the build in `.` can override the individual contracrt builds. This can only be solved by providing a path argument for filtering.
2. It is still unclear which source code will be used for verification. If we use the full repo for creating the builds, we also need to use the full repo for verifying them.