### PR TITLE
Shared compilation cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.10.7
+
+- Add shared build cache (sccache) to rust-optimizer
+
 ## 0.10.6
 
 - Add support for building multiple non-workspace contracts at once (#25)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
-DOCKER_TAG := 0.10.6
+DOCKER_TAG := 0.10.7
 
 build-rust-optimizer:
 	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --file rust-optimizer.Dockerfile .

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ you to produce a smaller build that works with the cosmwasm integration tests
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.10.6
+  cosmwasm/rust-optimizer:0.10.7
 ```
 
 Demo this with `cosmwasm-examples` (going into eg. `erc20` subdir before running),
@@ -57,7 +57,7 @@ To compile all contracts in the workspace deterministically, you can run:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.10.6
+  cosmwasm/workspace-optimizer:0.10.7
 ```
 
 The downside is that to verify one contract in the workspace, you need to compile them
@@ -83,7 +83,7 @@ case, we can use the optimize.sh command:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_burner",target=/code/contracts/burner/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.10.6 ./contracts/burner
+  cosmwasm/rust-optimizer:0.10.7 ./contracts/burner
 ```
 
 ## Development

--- a/optimize.sh
+++ b/optimize.sh
@@ -6,6 +6,9 @@ export PATH=$PATH:/root/.cargo/bin
 
 echo "Info: RUSTC_WRAPPER=$RUSTC_WRAPPER"
 
+echo "Info: sccache stats before build"
+sccache -s
+
 mkdir -p artifacts
 contractdirs="$@"
 
@@ -41,6 +44,9 @@ done
   cd artifacts
   sha256sum -- *.wasm > checksums.txt
 )
+
+echo "Info: sccache stats after build"
+sccache -s
 
 echo "done"
 done

--- a/optimize.sh
+++ b/optimize.sh
@@ -4,6 +4,8 @@ command -v shellcheck > /dev/null && shellcheck "$0"
 
 export PATH=$PATH:/root/.cargo/bin
 
+echo "Info: RUSTC_WRAPPER=$RUSTC_WRAPPER"
+
 mkdir -p artifacts
 contractdirs="$@"
 

--- a/optimize.sh
+++ b/optimize.sh
@@ -21,22 +21,22 @@ contractdirs="$@"
 # This parameter allows us to mount a folder into docker container's "/code"
 # and build "/code/contracts/mycontract".
 # Note: if contractdir is "." (default in Docker), this ends up as a noop
-for contractdir in $contractdirs
-do
-echo "Building contract in $(realpath -m "$contractdir")"
-(
-  cd "$contractdir"
+for contractdir in $contractdirs; do
+  echo "Building contract in $(realpath -m "$contractdir")"
+  (
+    cd "$contractdir"
 
-  # Linker flag "-s" for stripping (https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957)
-  # Note that shortcuts from .cargo/config are not available in source code packages from crates.io
-  RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown --locked
-)
+    # Linker flag "-s" for stripping (https://github.com/rust-lang/cargo/issues/3483#issuecomment-431209957)
+    # Note that shortcuts from .cargo/config are not available in source code packages from crates.io
+    RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown --locked
+  )
 
-# wasm-optimize on all results
-for wasm in "$contractdir"/target/wasm32-unknown-unknown/release/*.wasm; do
-  name=$(basename "$wasm")
-  echo "Optimizing $name"
-  wasm-opt -Os "$wasm" -o "artifacts/$name"
+  # wasm-optimize on all results
+  for wasm in "$contractdir"/target/wasm32-unknown-unknown/release/*.wasm; do
+    name=$(basename "$wasm")
+    echo "Optimizing $name"
+    wasm-opt -Os "$wasm" -o "artifacts/$name"
+  done
 done
 
 # create hash
@@ -49,4 +49,3 @@ echo "Info: sccache stats after build"
 sccache -s
 
 echo "done"
-done

--- a/rust-optimizer.Dockerfile
+++ b/rust-optimizer.Dockerfile
@@ -15,7 +15,7 @@ RUN mv binaryen-version_*/wasm-opt /usr/local/bin
 # Check wasm-opt version
 RUN wasm-opt --version
 
-# Add sscache
+# Add sccache
 RUN cargo install sccache
 ENV RUSTC_WRAPPER=sccache
 

--- a/rust-optimizer.Dockerfile
+++ b/rust-optimizer.Dockerfile
@@ -4,6 +4,11 @@ FROM rust:1.47.0
 # setup rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown
 
+# Install sccache from https://crates.io/crates/sccache
+# This is slow due to full release compilation from source.
+# Use full version string here to ensure Docker caching works well.
+RUN cargo install --version 0.2.13 sccache
+
 # Download binaryen and verify checksum
 ADD https://github.com/WebAssembly/binaryen/releases/download/version_96/binaryen-version_96-x86_64-linux.tar.gz /tmp/binaryen.tar.gz
 RUN sha256sum /tmp/binaryen.tar.gz | grep 9f8397a12931df577b244a27c293d7c976bc7e980a12457839f46f8202935aac
@@ -15,8 +20,7 @@ RUN mv binaryen-version_*/wasm-opt /usr/local/bin
 # Check wasm-opt version
 RUN wasm-opt --version
 
-# Add sccache
-RUN cargo install sccache
+# Use sccache. Users can override this variable to disable caching.
 ENV RUSTC_WRAPPER=sccache
 
 # Assume we mount the source code in /code

--- a/rust-optimizer.Dockerfile
+++ b/rust-optimizer.Dockerfile
@@ -15,6 +15,10 @@ RUN mv binaryen-version_*/wasm-opt /usr/local/bin
 # Check wasm-opt version
 RUN wasm-opt --version
 
+# Add sscache
+RUN cargo install sccache
+ENV RUSTC_WRAPPER=sccache
+
 # Assume we mount the source code in /code
 WORKDIR /code
 


### PR DESCRIPTION
Added shared compilation cache to `rust-optimizer`. Improvements are around 30/40 % compilation time, with a local cache.
Next step would be to add cloud storage for the cache (and / or for the `with_code` docker volume), but that is out of scope here.

When adding the same to `workspace-optimizer`, compilation is failing with an error:
```
sccache rustc - --crate-name ___ --print=file-names --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit code: 2)
  --- stderr
  error: failed to execute compile
  caused by: Failed to send data to or receive data from server
  caused by: Failed to read response header
  caused by: failed to fill whole buffer
```
This is probably related to `nightly` version being used. So, I've decided to let the cache out of `workspace-optimizer` for the moment. We can always try to add it later.

Closes #27.
