### PR TITLE
Switch back workspace-optimizer to Rust stable

### DIFF
--- a/build_workspace.py
+++ b/build_workspace.py
@@ -30,22 +30,9 @@ log("Package directories:", all_packages)
 contract_packages = [p for p in all_packages if p.startswith(PACKAGE_PREFIX)]
 log("Contracts to be built:", contract_packages)
 
-artifacts_dir = os.path.realpath("artifacts")
-os.makedirs(artifacts_dir, exist_ok=True)
-
 for contract in contract_packages:
     log("Building {} ...".format(contract))
-    # make a tmp dir for the output (*.wasm and other) to not touch the host filesystem
-    tmp_dir = "/tmp/" + contract
-    os.makedirs(tmp_dir, exist_ok=True)
 
-    # Rust nightly and unstable-options is needed to use --out-dir
-    cmd = [CARGO_PATH, "-Z=unstable-options", "build", "--release", "--target=wasm32-unknown-unknown", "--locked", "--out-dir={}".format(tmp_dir)]
+    cmd = [CARGO_PATH, "build", "--release", "--target=wasm32-unknown-unknown", "--locked"]
     os.environ["RUSTFLAGS"] = "-C link-arg=-s"
     subprocess.check_call(cmd, cwd=contract)
-
-    for build_result in glob.glob("{}/*.wasm".format(tmp_dir)):
-        log("Optimizing build {} ...".format(build_result))
-        name = os.path.basename(build_result)
-        cmd = ["wasm-opt", "-Os", "-o", "artifacts/{}".format(name), build_result]
-        subprocess.check_call(cmd)

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -32,11 +32,11 @@ TMPDIR=$(mktemp -d artifacts.XXX)
   done
 	mv ./*.wasm ../artifacts
 )
+rm -rf "$TMPDIR"
 echo "done."
 echo -n "Post-processing artifacts in workspace..."
 (
   cd artifacts
   sha256sum -- *.wasm >checksums.txt
 )
-rm -rf "$TMPDIR"
 echo "done."

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -17,7 +17,7 @@ echo "done."
 
 echo -n "Optimizing artifacts in workspace..."
 mkdir -p artifacts
-TMPDIR=$(mktemp -d artifacts.XXX)
+TMPDIR=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
 # Optimize artifacts
 (
   cd "$TMPDIR"

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -1,19 +1,33 @@
 #!/bin/bash
 set -o errexit -o nounset -o pipefail
-command -v shellcheck > /dev/null && shellcheck "$0"
+command -v shellcheck >/dev/null && shellcheck "$0"
 
 export PATH="$PATH:/root/.cargo/bin"
 
 rustup toolchain list
 cargo --version
 
-optimize_workspace.py
+# Build artifacts
+echo -n "Building artifacts in workspace..."
+/usr/local/bin/build_workspace.py
+echo "done."
 
-# Postprocess artifacts
+echo -n "Optimizing artifacts in workspace..."
+# Start clean
+rm -rf ./artifacts
+mkdir artifacts
+# Optimize and postprocess artifacts
 (
   cd artifacts
-  chmod -x ./*.wasm
-  sha256sum -- *.wasm > checksums.txt
-)
 
-echo "done"
+  for WASM in ../target/wasm32-unknown-unknown/release/*/*.wasm
+  do
+    echo -n "Optimizing $WASM..."
+    BASE=$(basename "$WASM")
+    wasm-opt -Os -o "$BASE" "$WASM"
+    chmod -x "$BASE"
+    echo "done."
+  done
+  sha256sum -- *.wasm >checksums.txt
+)
+echo "done."

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -17,10 +17,10 @@ echo "done."
 
 echo -n "Optimizing artifacts in workspace..."
 mkdir -p artifacts
-TMPDIR=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
+TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
 # Optimize artifacts
 (
-  cd "$TMPDIR"
+  cd "$TMPARTIFACTS"
 
   for WASM in ../target/wasm32-unknown-unknown/release/*/*.wasm
   do
@@ -32,7 +32,7 @@ TMPDIR=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
   done
 	mv ./*.wasm ../artifacts
 )
-rm -rf "$TMPDIR"
+rm -rf "$TMPARTIFACTS"
 echo "done."
 echo -n "Post-processing artifacts in workspace..."
 (

--- a/rust-optimizer.Dockerfile
+++ b/rust-optimizer.Dockerfile
@@ -1,7 +1,7 @@
 # Note: I tried slim and had issues compiling wasm-pack, even with --features vendored-openssl
 FROM rust:1.51.0
 
-# setup rust with Wasm support
+# Setup Rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown
 
 # Download sccache and verify checksum

--- a/workspace-optimizer.Dockerfile
+++ b/workspace-optimizer.Dockerfile
@@ -1,5 +1,3 @@
-# This version of Rust will not be used for compilation but just serves as a stable base image to get debian+rustup.
-# See Rust nightly config below.
 FROM rust:1.51.0
 
 # Setup Rust with Wasm support

--- a/workspace-optimizer.Dockerfile
+++ b/workspace-optimizer.Dockerfile
@@ -1,18 +1,15 @@
 # This version of Rust will not be used for compilation but just serves as a stable base image to get debian+rustup.
 # See Rust nightly config below.
 FROM rust:1.51.0
-RUN rustup toolchain remove 1.51.0
+
+# Setup Rust with Wasm support
+RUN rustup target add wasm32-unknown-unknown
 
 RUN apt update
 RUN apt install python3 python3-toml -y
 
 RUN python3 --version
 
-# Install Rust nightly
-# Choose version from: https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-RUN rustup toolchain install nightly-2021-03-01 --allow-downgrade --profile minimal --target wasm32-unknown-unknown
-RUN rustup default nightly-2021-03-01
-RUN rustup toolchain list
 # Check cargo version
 RUN cargo --version
 
@@ -32,9 +29,9 @@ RUN wasm-opt --version
 WORKDIR /code
 
 # Add our scripts as entry point
-ADD optimize_workspace.py /usr/local/bin/
+ADD build_workspace.py /usr/local/bin/
 ADD optimize_workspace.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/optimize_workspace.py
+RUN chmod +x /usr/local/bin/build_workspace.py
 RUN chmod +x /usr/local/bin/optimize_workspace.sh
 
 ENTRYPOINT ["optimize_workspace.sh"]


### PR DESCRIPTION
Avoids the need of Rust nightly and the extra `rustup` install, by separating building from optimizing artifacts.

Closes #34.