### PR TITLE
Use local / unqualified name for base-optimizer image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ build-base-optimizer:
 	docker tag $(DOCKER_NAME_BASE_OPTIMIZER):$(DOCKER_TAG) $(DOCKER_NAME_BASE_OPTIMIZER):latest
 
 build-rust-optimizer: build-base-optimizer
-	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --file rust-optimizer.Dockerfile .
+	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --pull=false --file rust-optimizer.Dockerfile .
 
 build-workspace-optimizer: build-base-optimizer
-	docker build -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --file workspace-optimizer.Dockerfile .
+	docker build -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --pull=false --file workspace-optimizer.Dockerfile .
 
 publish-rust-optimizer: build-rust-optimizer
 	docker push $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build-rust-optimizer build-workspace-optimizer build publish-rust-optimizer publish-workspace-optimizer publish
 
-DOCKER_NAME_BASE_OPTIMIZER := "cosmwasm/base-optimizer"
+DOCKER_NAME_BASE_OPTIMIZER := "base-optimizer"
 DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
 DOCKER_TAG := 0.11.5

--- a/rust-optimizer.Dockerfile
+++ b/rust-optimizer.Dockerfile
@@ -1,4 +1,4 @@
-FROM cosmwasm/base-optimizer:latest
+FROM base-optimizer:latest
 
 # Download sccache and verify checksum
 ADD https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz /tmp/sccache.tar.gz

--- a/workspace-optimizer.Dockerfile
+++ b/workspace-optimizer.Dockerfile
@@ -1,4 +1,4 @@
-FROM cosmwasm/base-optimizer:latest
+FROM base-optimizer:latest
 
 # Install Python
 RUN apk add python3 py3-toml


### PR DESCRIPTION
An attempt at fixing "`base-optimizer` not found" issues.