### PR TITLE
Use builder pattern to reduce image sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.12.1
+
+- Use the Docker builder pattern to reduce image sizes by preventing temporary files from
+  entering the `cosmwasm/rust-optimizer` and `cosmwasm/workspace-optimizer` images
+
 ## 0.12.0
 
 - Reorganize project to use multi-stage builds instead of different docker files. This

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
-#
-# base-optimizer
-#
-FROM rust:1.54.0-alpine as base-optimizer
-
-RUN apk update
-# Being required for gcc linking
-RUN apk add --no-cache musl-dev
-
-# Setup Rust with Wasm support
-RUN rustup target add wasm32-unknown-unknown
+FROM rust:1.54.0-alpine as builder
 
 # Check cargo version
 RUN cargo --version
@@ -20,15 +10,9 @@ RUN sha256sum /tmp/binaryen.tar.gz | grep 9f8397a12931df577b244a27c293d7c976bc7e
 # Extract and install wasm-opt
 RUN tar -xf /tmp/binaryen.tar.gz
 RUN mv binaryen-version_*/wasm-opt /usr/local/bin
-RUN rm -rf binaryen-version_*/ /tmp/binaryen.tar.gz
 
 # Check wasm-opt version
 RUN wasm-opt --version
-
-#
-# rust-optimizer
-#
-FROM base-optimizer as rust-optimizer
 
 # Download sccache and verify checksum
 ADD https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz /tmp/sccache.tar.gz
@@ -38,20 +22,48 @@ RUN sha256sum /tmp/sccache.tar.gz | grep e5d03a9aa3b9fac7e490391bbe22d4f42c840d3
 RUN tar -xf /tmp/sccache.tar.gz
 RUN mv sccache-v*/sccache /usr/local/bin/sccache
 RUN chmod +x /usr/local/bin/sccache
-RUN rm -rf sccache-v*/ /tmp/sccache.tar.gz
 
 # Check sccache version
 RUN sccache --version
 
+# Add scripts
+ADD optimize.sh /usr/local/bin/optimize.sh
+RUN chmod +x /usr/local/bin/optimize.sh
+
+ADD optimize_workspace.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/optimize_workspace.sh
+ADD build_workspace.py /usr/local/bin/
+RUN chmod +x /usr/local/bin/build_workspace.py
+
+#
+# base-optimizer
+#
+FROM rust:1.54.0-alpine as base-optimizer
+
+# Being required for gcc linking
+RUN apk update && \
+  apk add --no-cache musl-dev
+
+# Setup Rust with Wasm support
+RUN rustup target add wasm32-unknown-unknown
+
+# Add wasm-opt
+COPY --from=builder /usr/local/bin/wasm-opt /usr/local/bin
+
+#
+# rust-optimizer
+#
+FROM base-optimizer as rust-optimizer
+
 # Use sccache. Users can override this variable to disable caching.
+COPY --from=builder /usr/local/bin/sccache /usr/local/bin
 ENV RUSTC_WRAPPER=sccache
 
 # Assume we mount the source code in /code
 WORKDIR /code
 
-# Add out script as entry point
-ADD optimize.sh /usr/local/bin/optimize.sh
-RUN chmod +x /usr/local/bin/optimize.sh
+# Add script as entry point
+COPY --from=builder /usr/local/bin/optimize.sh /usr/local/bin
 
 ENTRYPOINT ["optimize.sh"]
 # Default argument when none is provided
@@ -69,11 +81,9 @@ RUN python3 --version
 # Assume we mount the source code in /code
 WORKDIR /code
 
-# Add our scripts as entry point
-ADD build_workspace.py /usr/local/bin/
-ADD optimize_workspace.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/build_workspace.py
-RUN chmod +x /usr/local/bin/optimize_workspace.sh
+# Add script as entry point
+COPY --from=builder /usr/local/bin/optimize_workspace.sh /usr/local/bin
+COPY --from=builder /usr/local/bin/build_workspace.py /usr/local/bin
 
 ENTRYPOINT ["optimize_workspace.sh"]
 # Default argument when none is provided

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
-DOCKER_TAG := 0.12.0
+DOCKER_TAG := 0.12.1
 
 build-rust-optimizer:
 	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer .


### PR DESCRIPTION
Builds on top of #53 to use the [builder pattern](https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds). Here, we do general work in a temporary builder stage and copy only the required files into the rust-optimizer and workspace-optimizer images. Anything that doesn't get copied into the final images is thrown away. This reduces image sizes by ~10% to 900MB. Note that rust:1.54.0-alpine is 786MB before we add any wasm specific stuff, so only adding ~100MB is quite good.

```
❯ docker image ls
REPOSITORY                     TAG             IMAGE ID       CREATED         SIZE
cosmwasm/rust-optimizer        0.12.1          4f80eb3b2ad0   3 hours ago     902MB
cosmwasm/workspace-optimizer   0.12.1          b7bb3c9473e4   3 hours ago     924MB
cosmwasm/workspace-optimizer   0.12.0          b9f4ed28322e   4 hours ago     1.03GB
cosmwasm/rust-optimizer        0.12.0          517921e0c25b   4 hours ago     1.06GB
```

The way the Dockerfiles were written before meant that files that were removed in separate `RUN` commands were still present in other layers, e.g.

https://github.com/CosmWasm/rust-optimizer/blob/5a519d85ec6a69fe46b7864607b0092267ade209/Dockerfile#L20-L23


The 0.12.0 and 0.12.1 containers produce identical wasm files:

```
❯ docker run --rm -v "$(pwd)":/code \
  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
  cosmwasm/rust-optimizer:0.12.0
...
❯ cat artifacts/checksums.txt
a25ad28b91754a99cfeadcb8f7f6f0570a118378cbd284938620089b4ada5268  terraswap_factory.wasm
f0a4828cd0df981d451e8544cc4d5f530b5e47c6c487856c0e9ced907da11d0e  terraswap_pair.wasm
d68f8b74597e9f374b48aad44ea7746203de4eee3b7cb9f9dde605ca43a21aa5  terraswap_router.wasm
86c1ed459c9030844adbbbae1793e05371672547ce387b33feb2c78100a796dd  terraswap_token.wasm
❯ docker run --rm -v "$(pwd)":/code \
  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
  cosmwasm/rust-optimizer:0.12.1-rc1
...
❯ cat artifacts/checksums.txt
a25ad28b91754a99cfeadcb8f7f6f0570a118378cbd284938620089b4ada5268  terraswap_factory.wasm
f0a4828cd0df981d451e8544cc4d5f530b5e47c6c487856c0e9ced907da11d0e  terraswap_pair.wasm
d68f8b74597e9f374b48aad44ea7746203de4eee3b7cb9f9dde605ca43a21aa5  terraswap_router.wasm
86c1ed459c9030844adbbbae1793e05371672547ce387b33feb2c78100a796dd  terraswap_token.wasm
```