### PR TITLE
Build multi-architecture Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.12.2
+
+- Support for arm64 Docker images.
+
 ## 0.12.1
 
 - Use the Docker builder pattern to reduce image sizes by preventing temporary files from

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-.PHONY: build-rust-optimizer build-workspace-optimizer build publish-rust-optimizer publish-workspace-optimizer publish
+.PHONY: build-rust-optimizer build-workspace-optimizer build create-rust-optimizer-builder use-rust-optimizer-builder publish-rust-optimizer publish-workspace-optimizer publish
 
 DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
-DOCKER_TAG := 0.12.1
+DOCKER_TAG := 0.12.2
+
+# Build images locally for the host CPU architecture
 
 build-rust-optimizer:
 	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer .
@@ -10,12 +12,21 @@ build-rust-optimizer:
 build-workspace-optimizer:
 	docker build -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer .
 
-publish-rust-optimizer: build-rust-optimizer
-	docker push $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG)
-
-publish-workspace-optimizer: build-workspace-optimizer
-	docker push $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG)
-
 build: build-rust-optimizer build-workspace-optimizer
+
+# Build multi-CPU architecture images and publish them. rust alpine images support the linux/amd64 and linux/arm64/v8 architectures.
+
+create-rust-optimizer-builder:
+	docker buildx create --name rust-optimizer-builder
+
+# create-rust-optimizer-builder must be run before running use-rust-optimizer-builder for the first time
+use-rust-optimizer-builder:
+	docker buildx use rust-optimizer-builder
+
+publish-rust-optimizer: use-rust-optimizer-builder
+	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --push .
+
+publish-workspace-optimizer: use-rust-optimizer-builder
+	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --push .
 
 publish: publish-rust-optimizer publish-workspace-optimizer

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ you to produce a smaller build that works with the cosmwasm integration tests
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.1
+  cosmwasm/rust-optimizer:0.12.2
 ```
 
 Demo this with `cosmwasm-examples` (going into eg. `erc20` subdir before running),
@@ -60,7 +60,7 @@ To compile all contracts in the workspace deterministically, you can run:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.1
+  cosmwasm/workspace-optimizer:0.12.2
 ```
 
 The downside is that to verify one contract in the workspace, you need to compile them
@@ -86,7 +86,7 @@ case, we can use the optimize.sh command:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_burner",target=/code/contracts/burner/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.1 ./contracts/burner
+  cosmwasm/rust-optimizer:0.12.2 ./contracts/burner
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -89,35 +89,6 @@ docker run --rm -v "$(pwd)":/code \
   cosmwasm/rust-optimizer:0.12.1 ./contracts/burner
 ```
 
-## Using on M1 Macs (ARM processor)
-
-The images on DockerHub are not yet built for ARM (see [#49]). Some people successfully use
-the x86 images through emulation. But this tends to be slow and may crash due to increased
-memory consumption.
-
-A workaround for the problem is to build the images locally on an M1 Mac.
-
-```
-$ git clone https://github.com/CosmWasm/rust-optimizer.git
-$ cd rust-optimizer
-$ git checkout v0.12.1
-$ make build
-```
-
-You now have the images available locally built for your platform.
-
-```
-$ docker image ls | grep cosmwasm/
-cosmwasm/workspace-optimizer   0.12.1        aa29e67e7612   10 seconds ago   1.03GB
-cosmwasm/rust-optimizer        0.12.1        d8d95af0a0c4   17 seconds ago   1.06GB
-```
-
-While this is better than nothing, it creates the risk that contracts cannot
-be built reproducibly. For this reason a solution to [#49] means getting
-ARM builds to DockerHub that are used by everyone.
-
-[#49]: https://github.com/CosmWasm/rust-optimizer/issues/49
-
 ## Development
 
 Take a look at the [Makefile](https://github.com/CosmWasm/rust-optimizer/blob/master/Makefile)


### PR DESCRIPTION
Use Docker buildx to build [multi-CPU architecture Docker images](https://docs.docker.com/desktop/multi-arch/).

[rust alpine images](https://hub.docker.com/_/rust?tab=tags&page=1&ordering=last_updated) support the linux/amd64 and linux/arm64/v8 architectures, so we can build rust-optimizer and workspace-optimizer images that also support these architectures.

I built the multi-arch rust-optimizer images on an x86 machine and pushed them to [Docker Hub](https://hub.docker.com/r/harryscholes/rust-optimizer-test/tags). You can see that the registry has images for `linux/arm64` and `linux/amd64` architectures 🎉

## Benchmarking

I then benchmarked the arm64 image that was built on an x86 machine (v0.12.2) against an arm64 image built on a Mac M1 arm64 machine (v0.12.1) by building the terraswap contracts:

built on | run on | version | wall time
---|---|---|---
arm64 | arm64 | 0.12.1 | 2:36
amd64 | arm64 | 0.12.2 | 3:10

In this test, arm64 images built on amd64 machines are ~20% slower than arm64 images built on arm64 machines. But we gain more than we lose here, as we now have the ability to ship arm64 images. Also note that this benchmark is slightly contrived in that no caching was allowed, and a large amount of time is spent on network io downloading crates.

Benchmark commands:

```
time docker run --rm -v "$(pwd)":/code cosmwasm/rust-optimizer:0.12.1
rm -rf target
time docker run --rm -v "$(pwd)":/code harryscholes/rust-optimizer-test:0.12.2
```

closes #49 