### PR TITLE
Arm64 support 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
           name: Install docker-ce
           command: |
             apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
+            curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
             echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
             apt update
             apt install -y docker-ce docker-ce-cli containerd.io qemu-user-static binfmt-support

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,13 +45,13 @@ jobs:
             apt update
             apt install -y git make
       - run:
-          name: Install docker-ce cli (buildx)
+          name: Install docker-ce (buildx)
           command: |
             apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
             echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
             apt update
-            apt install -y docker-ce-cli
+            apt install -y docker-ce docker-ce-cli containerd.io
       - checkout
       - run:
           name: Build docker artifacts (linux/arm64)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,17 @@ jobs:
             apt update
             apt install -y git make
       - run:
-          name: Install docker-ce
+          name: Install docker-ce (buildx)
           command: |
             apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
             curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
             echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
             apt update
-            apt install -y docker-ce docker-ce-cli containerd.io qemu-user-static binfmt-support
-            # TODO: Check support for qemu / binfmt is enabled
+            apt install -y docker-ce docker-ce-cli containerd.io
+      - run:
+          name: Install multi-arch support (qemu + binfmt)
+          command: |
+            apt install -y qemu-user-static binfmt-support
       - checkout
       - setup_remote_docker:
           # We might want to add this when things get slow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: make build-rust-optimizer-x86_64 build-workspace-optimizer-x86_64
       - run:
           name: Build docker artifacts (linux/arm64)
-          command: make build-rust-optimizer-aarch64 build-workspace-optimizer-aarch64
+          command: make build-rust-optimizer-arm64 build-workspace-optimizer-arm64
   lint-scripts:
     executor: ubuntu
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,11 @@ jobs:
           # https://circleci.com/docs/2.0/docker-layer-caching/
           docker_layer_caching: false
       - run:
-          name: Build docker multi-platform artifacts
-          command: make build
+          name: Build docker artifacts (linux/amd64)
+          command: make build-rust-optimizer-x86_64 build-workspace-optimizer-x86_64
+      - run:
+          name: Build docker artifacts (linux/arm64)
+          command: make build-rust-optimizer-aarch64 build-workspace-optimizer-aarch64
   lint-scripts:
     executor: debian
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,17 +15,13 @@ jobs:
             apt update
             apt install -y git make
       - run:
-          name: Install docker-ce (buildx)
+          name: Install docker-ce cli (buildx)
           command: |
             apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
             curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
             echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
             apt update
-            apt install -y docker-ce docker-ce-cli containerd.io
-      - run:
-          name: Install multi-arch support (qemu + binfmt)
-          command: |
-            apt install -y qemu-user-static binfmt-support
+            apt install -y docker-ce-cli
       - checkout
       - setup_remote_docker:
           # We might want to add this when things get slow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,16 +42,16 @@ jobs:
       - run:
           name: Install packages
           command: |
-            apt update
-            apt install -y git make
+            sudo apt update
+            sudo apt install -y git make
       - run:
           name: Install docker-ce (buildx)
           command: |
-            apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
-            apt update
-            apt install -y docker-ce docker-ce-cli containerd.io
+            sudo apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+            sudo apt update
+            sudo apt install -y docker-ce docker-ce-cli containerd.io
       - checkout
       - run:
           name: Build docker artifacts (linux/arm64)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,19 @@
 version: 2.1
 
 executors:
-  ubuntu:
+  ubuntu-amd64:
     docker:
       - image: ubuntu:20.04
+  ubuntu-arm64:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.large
 
 jobs:
-  build:
-    executor: ubuntu
+  build-amd64:
+    executor: ubuntu-amd64
     steps:
+      - run: uname -a
       - run:
           name: Install packages
           command: |
@@ -30,11 +35,33 @@ jobs:
       - run:
           name: Build docker artifacts (linux/amd64)
           command: make build-rust-optimizer-x86_64 build-workspace-optimizer-x86_64
+  build-arm64:
+    executor: ubuntu-arm64
+    steps:
+      - run: uname -a
+      - run:
+          name: Install packages
+          command: |
+            apt update
+            apt install -y git make
+      - run:
+          name: Install docker-ce cli (buildx)
+          command: |
+            apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
+            apt update
+            apt install -y docker-ce-cli
+      - checkout
+      - setup_remote_docker:
+          # We might want to add this when things get slow
+          # https://circleci.com/docs/2.0/docker-layer-caching/
+          docker_layer_caching: false
       - run:
           name: Build docker artifacts (linux/arm64)
           command: make build-rust-optimizer-arm64 build-workspace-optimizer-arm64
   lint-scripts:
-    executor: ubuntu
+    executor: ubuntu-amd64
     steps:
       - run:
           name: Install packages
@@ -61,6 +88,7 @@ workflows:
   version: 2
   test-suite:
     jobs:
-      - build
+      - build-amd64
+      - build-arm64
       - lint-scripts
       - format-scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,37 @@
 version: 2.1
 
 executors:
-  ubuntu:
+  debian:
     docker:
-      - image: ubuntu:20.04
+      - image: debian:bullseye
 
 jobs:
   build:
-    executor: ubuntu
+    executor: debian
     steps:
       - run:
           name: Install packages
           command: |
             apt update
-            apt install -y git make docker.io
+            apt install -y git make
+      - run:
+          name: Install docker-ce
+          command: |
+            apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
+            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
+            apt update
+            apt install -y docker-ce docker-ce-cli containerd.io qemu-user-static binfmt-support
+            # TODO: Check support for qemu / binfmt is enabled
       - checkout
       - setup_remote_docker:
           # We might want to add this when things get slow
           # https://circleci.com/docs/2.0/docker-layer-caching/
           docker_layer_caching: false
       - run:
-          name: Build Docker artifact
+          name: Build docker multi-platform artifacts
           command: make build
   lint-scripts:
-    executor: ubuntu
+    executor: debian
     steps:
       - run:
           name: Install packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,6 @@ jobs:
             apt update
             apt install -y docker-ce-cli
       - checkout
-      - setup_remote_docker:
-          # We might want to add this when things get slow
-          # https://circleci.com/docs/2.0/docker-layer-caching/
-          docker_layer_caching: false
       - run:
           name: Build docker artifacts (linux/arm64)
           command: make build-rust-optimizer-arm64 build-workspace-optimizer-arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 
 executors:
-  debian:
+  ubuntu:
     docker:
-      - image: debian:bullseye
+      - image: ubuntu:20.04
 
 jobs:
   build:
-    executor: debian
+    executor: ubuntu
     steps:
       - run:
           name: Install packages
@@ -18,8 +18,8 @@ jobs:
           name: Install docker-ce cli (buildx)
           command: |
             apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
-            curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list >/dev/null
             apt update
             apt install -y docker-ce-cli
       - checkout
@@ -34,7 +34,7 @@ jobs:
           name: Build docker artifacts (linux/arm64)
           command: make build-rust-optimizer-aarch64 build-workspace-optimizer-aarch64
   lint-scripts:
-    executor: debian
+    executor: ubuntu
     steps:
       - run:
           name: Install packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.12.2
+
+- Support for arm64 Docker images.
+
 ## 0.12.1
 
 - Use the Docker builder pattern to reduce image sizes by preventing temporary files from

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM rust:1.54.0-alpine as builder
+FROM rust:1.54.0-alpine as targetarch
 
-ARG ARCH
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+ARG TARGETARCH
 
+RUN echo "Running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+FROM targetarch as builder-amd64
+ARG ARCH="x86_64"
+
+FROM targetarch as builder-arm64
+ARG ARCH="aarch64"
+
+FROM builder-${TARGETARCH} as builder
 # Check cargo version
 RUN cargo --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM rust:1.54.0-alpine as builder
 
+ARG ARCH
+
 # Check cargo version
 RUN cargo --version
 
 # Download sccache and verify checksum
-ADD https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz /tmp/sccache.tar.gz
-RUN sha256sum /tmp/sccache.tar.gz | grep e5d03a9aa3b9fac7e490391bbe22d4f42c840d31ef9eaf127a03101930cbb7ca
+ADD https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-$ARCH-unknown-linux-musl.tar.gz /tmp/sccache.tar.gz
+RUN sha256sum /tmp/sccache.tar.gz | egrep '(e5d03a9aa3b9fac7e490391bbe22d4f42c840d31ef9eaf127a03101930cbb7ca|90d91d21a767e3f558196dbd52395f6475c08de5c4951a4c8049575fa6894489)'
 
 # Extract and install sccache
 RUN tar -xf /tmp/sccache.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,6 @@ FROM rust:1.54.0-alpine as builder
 # Check cargo version
 RUN cargo --version
 
-# Install platform-specific binaryen
-RUN apk update && apk add binaryen
-
-# Check wasm-opt version
-RUN wasm-opt --version
-
 # Download sccache and verify checksum
 ADD https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-unknown-linux-musl.tar.gz /tmp/sccache.tar.gz
 RUN sha256sum /tmp/sccache.tar.gz | grep e5d03a9aa3b9fac7e490391bbe22d4f42c840d31ef9eaf127a03101930cbb7ca
@@ -40,7 +34,7 @@ RUN apk update && \
   apk add --no-cache musl-dev
 
 # Install platform-specific binaryen
-RUN apk add binaryen
+RUN apk add binaryen=98-r0
 
 # Setup Rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,14 @@ ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH
 
-ARG BINARYEN_VERSION="version_101"
-ARG BINARYEN_CHECKSUM="20d0b19ca716c51d927f181802125f04d5685250c8a22ec3022ac28bf4f20c57"
+ARG BINARYEN_VERSION="version_96"
+ARG BINARYEN_CHECKSUM="9f8397a12931df577b244a27c293d7c976bc7e980a12457839f46f8202935aac"
 
 RUN echo "Running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
 # AMD64
 FROM targetarch as builder-amd64
 ARG ARCH="x86_64"
-
 
 # Download binaryen binary and verify checksum
 ADD https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_VERSION/binaryen-$BINARYEN_VERSION-x86_64-linux.tar.gz /tmp/binaryen.tar.gz
@@ -34,12 +33,13 @@ RUN apk update && apk add build-base cmake git python3 clang ninja
 RUN tar -xf /tmp/binaryen.tar.gz
 RUN cd binaryen-version_*/ && cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON && ninja wasm-opt
 RUN strip binaryen-version_*/bin/wasm-opt
+RUN mv binaryen-version_*/bin/wasm-opt binaryen-version_*/
 
 # GENERIC
 FROM builder-${TARGETARCH} as builder
 
 # Install wasm-opt
-RUN mv binaryen-version_*/bin/wasm-opt /usr/local/bin
+RUN mv binaryen-version_*/wasm-opt /usr/local/bin
 
 # Check cargo version
 RUN cargo --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,8 @@ FROM rust:1.54.0-alpine as builder
 # Check cargo version
 RUN cargo --version
 
-# Download binaryen and verify checksum
-ADD https://github.com/WebAssembly/binaryen/releases/download/version_96/binaryen-version_96-x86_64-linux.tar.gz /tmp/binaryen.tar.gz
-RUN sha256sum /tmp/binaryen.tar.gz | grep 9f8397a12931df577b244a27c293d7c976bc7e980a12457839f46f8202935aac
-
-# Extract and install wasm-opt
-RUN tar -xf /tmp/binaryen.tar.gz
-RUN mv binaryen-version_*/wasm-opt /usr/local/bin
+# Install platform-specific binaryen
+RUN apk update && apk add binaryen
 
 # Check wasm-opt version
 RUN wasm-opt --version
@@ -44,11 +39,11 @@ FROM rust:1.54.0-alpine as base-optimizer
 RUN apk update && \
   apk add --no-cache musl-dev
 
+# Install platform-specific binaryen
+RUN apk add binaryen
+
 # Setup Rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown
-
-# Add wasm-opt
-COPY --from=builder /usr/local/bin/wasm-opt /usr/local/bin
 
 #
 # rust-optimizer

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN sha256sum /tmp/binaryen.tar.gz | grep fe140191607c76f02bd0f1cc641715cefcb48e
 RUN apk update && apk add build-base cmake git clang ninja
 RUN tar -xf /tmp/binaryen.tar.gz
 RUN cd binaryen-version_*/ && cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON && ninja wasm-opt
-RUN strip -x binaryen-version_*/bin/wasm-opt
+RUN strip binaryen-version_*/bin/wasm-opt
 RUN mv binaryen-version_*/bin/wasm-opt binaryen-version_*/
 
 # GENERIC

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ FROM builder-${TARGETARCH} as builder
 # Check cargo version
 RUN cargo --version
 
+# Install platform-specific binaryen
+RUN apk update && apk add binaryen
+
+# Check wasm-opt version
+RUN wasm-opt --version
+
 # Download sccache and verify checksum
 ADD https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-$ARCH-unknown-linux-musl.tar.gz /tmp/sccache.tar.gz
 RUN sha256sum /tmp/sccache.tar.gz | egrep '(e5d03a9aa3b9fac7e490391bbe22d4f42c840d31ef9eaf127a03101930cbb7ca|90d91d21a767e3f558196dbd52395f6475c08de5c4951a4c8049575fa6894489)'
@@ -47,7 +53,7 @@ RUN apk update && \
   apk add --no-cache musl-dev
 
 # Install platform-specific binaryen
-RUN apk add binaryen=98-r0
+RUN apk add binaryen
 
 # Setup Rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ADD https://github.com/WebAssembly/binaryen/archive/refs/tags/$BINARYEN_VERSION.
 
 # Extract and compile wasm-opt
 # Adapted from https://github.com/WebAssembly/binaryen/blob/main/.github/workflows/build_release.yml
-RUN apk update && apk add build-base cmake git clang ninja
+RUN apk update && apk add build-base cmake git python3 clang ninja
 RUN tar -xf /tmp/binaryen.tar.gz
 RUN cd binaryen-version_*/ && cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON && ninja wasm-opt
 RUN strip binaryen-version_*/bin/wasm-opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN sha256sum /tmp/binaryen.tar.gz | grep fe140191607c76f02bd0f1cc641715cefcb48e
 
 # Extract and compile wasm-opt
 # Adapted from https://github.com/WebAssembly/binaryen/blob/main/.github/workflows/build_release.yml
-RUN apk update && apk add build-base cmake git python3 clang ninja
+RUN apk update && apk add build-base cmake git clang ninja
 RUN tar -xf /tmp/binaryen.tar.gz
 RUN cd binaryen-version_*/ && cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON && ninja wasm-opt
 RUN strip -x binaryen-version_*/bin/wasm-opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN sha256sum /tmp/binaryen.tar.gz | grep fe140191607c76f02bd0f1cc641715cefcb48e
 RUN apk update && apk add build-base cmake git python3 clang ninja
 RUN tar -xf /tmp/binaryen.tar.gz
 RUN cd binaryen-version_*/ && cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON && ninja wasm-opt
-RUN strip -x binaryen-version_*/wasm-opt
+RUN strip -x binaryen-version_*/bin/wasm-opt
+RUN mv binaryen-version_*/bin/wasm-opt binaryen-version_*/
 
 # GENERIC
 FROM builder-${TARGETARCH} as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH
 
+ARG BINARYEN="version_101"
+
 RUN echo "Running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
 # AMD64
@@ -11,7 +13,7 @@ FROM targetarch as builder-amd64
 ARG ARCH="x86_64"
 
 # Download binaryen binary and verify checksum
-ADD https://github.com/WebAssembly/binaryen/releases/download/version_96/binaryen-version_96-x86_64-linux.tar.gz /tmp/binaryen.tar.gz
+ADD https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN/binaryen-$BINARYEN-x86_64-linux.tar.gz /tmp/binaryen.tar.gz
 RUN sha256sum /tmp/binaryen.tar.gz | grep 9f8397a12931df577b244a27c293d7c976bc7e980a12457839f46f8202935aac
 
 # Extract wasm-opt
@@ -22,7 +24,7 @@ FROM targetarch as builder-arm64
 ARG ARCH="aarch64"
 
 # Download binaryen sources and verify checksum
-ADD https://github.com/WebAssembly/binaryen/archive/refs/tags/version_96.tar.gz /tmp/binaryen.tar.gz
+ADD https://github.com/WebAssembly/binaryen/archive/refs/tags/$BINARYEN.tar.gz /tmp/binaryen.tar.gz
 RUN sha256sum /tmp/binaryen.tar.gz | grep fe140191607c76f02bd0f1cc641715cefcb48e723409418c2a39a50905a4514c
 
 # Extract and compile wasm-opt

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-rust-optimizer-arm64: use-rust-optimizer-multi
 build-workspace-optimizer-x86_64: use-rust-optimizer-multi
 	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
 
-build-workspace-optimizer-aarch64: use-rust-optimizer-multi
+build-workspace-optimizer-arm64: use-rust-optimizer-multi
 	docker buildx build --platform linux/arm64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
 
 # Build only the native version by default

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-rust-optimizer build-workspace-optimizer build create-rust-optimizer-builder use-rust-optimizer-builder publish-rust-optimizer publish-workspace-optimizer publish
+.PHONY: build-rust-optimizer build-workspace-optimizer build create-rust-optimizer-multi use-rust-optimizer-multi publish-rust-optimizer publish-workspace-optimizer publish
 
 DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ use-rust-optimizer-multi:
 build-rust-optimizer-x86_64: use-rust-optimizer-multi
 	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
 
-build-rust-optimizer-aarch64: use-rust-optimizer-multi
+build-rust-optimizer-arm64: use-rust-optimizer-multi
 	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
 
 build-workspace-optimizer-x86_64: use-rust-optimizer-multi

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-.PHONY: build-rust-optimizer build-workspace-optimizer build publish-rust-optimizer publish-workspace-optimizer publish
+.PHONY: build-rust-optimizer build-workspace-optimizer build create-rust-optimizer-builder use-rust-optimizer-builder publish-rust-optimizer publish-workspace-optimizer publish
 
 DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
-DOCKER_TAG := 0.12.1
+DOCKER_TAG := 0.12.2
+
+# Build images locally for the host CPU architecture
 
 build-rust-optimizer:
 	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer .
@@ -10,12 +12,21 @@ build-rust-optimizer:
 build-workspace-optimizer:
 	docker build -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer .
 
-publish-rust-optimizer: build-rust-optimizer
-	docker push $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG)
-
-publish-workspace-optimizer: build-workspace-optimizer
-	docker push $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG)
-
 build: build-rust-optimizer build-workspace-optimizer
+
+# Build multi-CPU architecture images and publish them. rust alpine images support the linux/amd64 and linux/arm64/v8 architectures.
+
+create-rust-optimizer-builder:
+	docker buildx create --name rust-optimizer-builder
+
+# create-rust-optimizer-builder must be run before running use-rust-optimizer-builder for the first time
+use-rust-optimizer-builder:
+	docker buildx use rust-optimizer-builder
+
+publish-rust-optimizer: use-rust-optimizer-builder
+	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --push .
+
+publish-workspace-optimizer: use-rust-optimizer-builder
+	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --push .
 
 publish: publish-rust-optimizer publish-workspace-optimizer

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,15 @@ DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
 DOCKER_TAG := 0.12.2
 
+ARCH := $(shell uname -m)
+
 # Build images locally for the host CPU architecture
 
 build-rust-optimizer:
-	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer .
+	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=$(ARCH) --target rust-optimizer .
 
 build-workspace-optimizer:
-	docker build -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer .
+	docker build -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=$(ARCH) --target workspace-optimizer .
 
 build: build-rust-optimizer build-workspace-optimizer
 
@@ -24,21 +26,23 @@ use-rust-optimizer-multi:
 	docker buildx use rust-optimizer-multi
 
 build-rust-optimizer-amd64: use-rust-optimizer-multi
-	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=x86_64 --target rust-optimizer --load .
 
 build-rust-optimizer-arm64: use-rust-optimizer-multi
-	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
+	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=aarch64 --target rust-optimizer --load .
 
-build-workspace-optimize-amd64: use-rust-optimizer-multi
-	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
+build-workspace-optimizer-amd64: use-rust-optimizer-multi
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=x86_64 --target workspace-optimizer --load .
 
-build-workspace-optimize-amd64: use-rust-optimizer-multi
-	docker buildx build --platform linux/arm64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
+build-workspace-optimizer-arm64: use-rust-optimizer-multi
+	docker buildx build --platform linux/arm64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=$(ARCH) --target workspace-optimizer --load .
 
 publish-rust-optimizer: use-rust-optimizer-multi
-	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --push .
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=x86_64 --target rust-optimizer --push .
+	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=aarch64 --target rust-optimizer --push .
 
 publish-workspace-optimizer: use-rust-optimizer-multi
-	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --push .
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=x86_64 --target workspace-optimizer --push .
+	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=aarch64 --target workspace-optimizer --push .
 
 publish: publish-rust-optimizer publish-workspace-optimizer

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ BUILDARCH := $(shell uname -m)
 build: build-rust-optimizer build-workspace-optimizer
 
 create-rust-optimizer-multi:
-	docker buildx create --name rust-optimizer-multi
+	docker context create rust-optimizer-multi
+	docker buildx create --name rust-optimizer-multi rust-optimizer-multi
 
 use-rust-optimizer-multi:
 	$(MAKE) create-rust-optimizer-multi || true

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,29 @@ build: build-rust-optimizer build-workspace-optimizer
 
 # Build multi-CPU architecture images and publish them. rust alpine images support the linux/amd64 and linux/arm64/v8 architectures.
 
-create-rust-optimizer-builder:
-	docker buildx create --name rust-optimizer-builder
+create-rust-optimizer-multi:
+	docker buildx create --name rust-optimizer-multi
 
-# create-rust-optimizer-builder must be run before running use-rust-optimizer-builder for the first time
-use-rust-optimizer-builder:
-	docker buildx use rust-optimizer-builder
+use-rust-optimizer-multi:
+	$(MAKE) create-rust-optimizer-multi || true
+	docker buildx use rust-optimizer-multi
 
-publish-rust-optimizer: use-rust-optimizer-builder
+build-rust-optimizer-amd64: use-rust-optimizer-multi
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
+
+build-rust-optimizer-arm64: use-rust-optimizer-multi
+	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
+
+build-workspace-optimize-amd64: use-rust-optimizer-multi
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
+
+build-workspace-optimize-amd64: use-rust-optimizer-multi
+	docker buildx build --platform linux/arm64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
+
+publish-rust-optimizer: use-rust-optimizer-multi
 	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --push .
 
-publish-workspace-optimizer: use-rust-optimizer-builder
+publish-workspace-optimizer: use-rust-optimizer-multi
 	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --push .
 
 publish: publish-rust-optimizer publish-workspace-optimizer

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,11 @@ DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
 DOCKER_TAG := 0.12.2
 
-ARCH := $(shell uname -m)
-
-# Build images locally for the host CPU architecture
-
-build-rust-optimizer:
-	docker build -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=$(ARCH) --target rust-optimizer .
-
-build-workspace-optimizer:
-	docker build -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=$(ARCH) --target workspace-optimizer .
-
-build: build-rust-optimizer build-workspace-optimizer
+# Native arch
+BUILDARCH := $(shell uname -m)
 
 # Build multi-CPU architecture images and publish them. rust alpine images support the linux/amd64 and linux/arm64/v8 architectures.
+build: build-rust-optimizer build-workspace-optimizer
 
 create-rust-optimizer-multi:
 	docker buildx create --name rust-optimizer-multi
@@ -25,24 +17,28 @@ use-rust-optimizer-multi:
 	$(MAKE) create-rust-optimizer-multi || true
 	docker buildx use rust-optimizer-multi
 
-build-rust-optimizer-amd64: use-rust-optimizer-multi
-	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=x86_64 --target rust-optimizer --load .
+build-rust-optimizer-x86_64: use-rust-optimizer-multi
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
 
-build-rust-optimizer-arm64: use-rust-optimizer-multi
-	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=aarch64 --target rust-optimizer --load .
+build-rust-optimizer-aarch64: use-rust-optimizer-multi
+	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
 
-build-workspace-optimizer-amd64: use-rust-optimizer-multi
-	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=x86_64 --target workspace-optimizer --load .
+build-workspace-optimizer-x86_64: use-rust-optimizer-multi
+	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
 
-build-workspace-optimizer-arm64: use-rust-optimizer-multi
-	docker buildx build --platform linux/arm64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=$(ARCH) --target workspace-optimizer --load .
+build-workspace-optimizer-aarch64: use-rust-optimizer-multi
+	docker buildx build --platform linux/arm64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
+
+# Build only the native version by default
+build-rust-optimizer: build-rust-optimizer-$(BUILDARCH)
+
+# Build only the native version by default
+build-workspace-optimizer: build-workspace-optimizer-$(BUILDARCH)
 
 publish-rust-optimizer: use-rust-optimizer-multi
-	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=x86_64 --target rust-optimizer --push .
-	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=aarch64 --target rust-optimizer --push .
+	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --push .
 
 publish-workspace-optimizer: use-rust-optimizer-multi
-	docker buildx build --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=x86_64 --target workspace-optimizer --push .
-	docker buildx build --platform linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --build-arg ARCH=aarch64 --target workspace-optimizer --push .
+	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --push .
 
 publish: publish-rust-optimizer publish-workspace-optimizer

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ you to produce a smaller build that works with the cosmwasm integration tests
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.1
+  cosmwasm/rust-optimizer:0.12.2
 ```
 
 Demo this with `cosmwasm-examples` (going into eg. `erc20` subdir before running),
@@ -60,7 +60,7 @@ To compile all contracts in the workspace deterministically, you can run:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.1
+  cosmwasm/workspace-optimizer:0.12.2
 ```
 
 The downside is that to verify one contract in the workspace, you need to compile them
@@ -86,7 +86,7 @@ case, we can use the optimize.sh command:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="devcontract_cache_burner",target=/code/contracts/burner/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.1 ./contracts/burner
+  cosmwasm/rust-optimizer:0.12.2 ./contracts/burner
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -89,35 +89,6 @@ docker run --rm -v "$(pwd)":/code \
   cosmwasm/rust-optimizer:0.12.1 ./contracts/burner
 ```
 
-## Using on M1 Macs (ARM processor)
-
-The images on DockerHub are not yet built for ARM (see [#49]). Some people successfully use
-the x86 images through emulation. But this tends to be slow and may crash due to increased
-memory consumption.
-
-A workaround for the problem is to build the images locally on an M1 Mac.
-
-```
-$ git clone https://github.com/CosmWasm/rust-optimizer.git
-$ cd rust-optimizer
-$ git checkout v0.12.1
-$ make build
-```
-
-You now have the images available locally built for your platform.
-
-```
-$ docker image ls | grep cosmwasm/
-cosmwasm/workspace-optimizer   0.12.1        aa29e67e7612   10 seconds ago   1.03GB
-cosmwasm/rust-optimizer        0.12.1        d8d95af0a0c4   17 seconds ago   1.06GB
-```
-
-While this is better than nothing, it creates the risk that contracts cannot
-be built reproducibly. For this reason a solution to [#49] means getting
-ARM builds to DockerHub that are used by everyone.
-
-[#49]: https://github.com/CosmWasm/rust-optimizer/issues/49
-
 ## Development
 
 Take a look at the [Makefile](https://github.com/CosmWasm/rust-optimizer/blob/master/Makefile)


### PR DESCRIPTION
Based on #55. Improves naming and adds some targets for building multi-arch (amd64 and arm64) images locally.

Also, switches to native `binaryen` for each platform.

`sccache` has the same issue, in that it is an `amd64` binary and will therefore require qemu + binfmt_misc to run on amr64 hosts.
~~Will try to improve on that in another iteration, later.~~ (done).

This now uses all native binaries. So that users wouldn't require emulation anymore to run these images on ARM.

Next steps would be:

- ~~Switch to using only `docker buildx`, for simplicity and features.~~ (done)
- Check that all images work / produce correct optimized wasm contracts.
- Integrate with the CI, so that docker-ce (plus qemu) is installed and used, and build / cross-build amd64 and arm64 images.
- Publish both amd64 and arm64 images.