### PR TITLE
Add is_dir check to build workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update to binaryen v102. Build binaryen from sources and test it in both,
   Intel and Arm 64.
 - Adds the "-arm64" suffix to Arm 64 image names. Also adds a suffix to non-x86_64 (Intel 64 bits) built artifacts.
+- Add missing "is directory" check for build workspace, to avoid panic on extra typescript files.
 
 ## 0.12.3
 

--- a/build_workspace/src/main.rs
+++ b/build_workspace/src/main.rs
@@ -27,7 +27,14 @@ fn main() {
 
     let mut all_packages = members
         .iter()
-        .map(|member| glob(member).unwrap().map(|path| path.unwrap()))
+        .map(|member| {
+            glob(member)
+                .unwrap()
+                .map(|path| path.unwrap())
+                // Checks whether given path is a directory, since additional
+                // files may cause panic later
+                .filter(|path| path.is_dir())
+        })
         .flatten()
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
closes https://github.com/CosmWasm/rust-optimizer/issues/68

I tried to make "smarter" map, by changing it to `.filter_map()` like:
```rust
.filter_map(|path| path.unwrap().is_dir().then(|| 0))
```
but it resulted in double reference which would have to be extra handled later on, so I decided that adding simple `.filter()` is good enough.

(this `.then()` trick is something I found to make `bool` into `Option<T>` [link](https://doc.rust-lang.org/std/primitive.bool.html#method.then))