### PR TITLE
Update to current Rust stable (v1.58.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bump Rust to current stable v1.58.1
+
 ## 0.12.4
 
 - Update to binaryen v102. Build binaryen from sources and test it in both,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.55.0-alpine as targetarch
+FROM rust:1.58.1-alpine as targetarch
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
@@ -77,7 +77,7 @@ RUN cd build_workspace && \
 #
 # base-optimizer
 #
-FROM rust:1.55.0-alpine as base-optimizer
+FROM rust:1.58.1-alpine as base-optimizer
 
 # Being required for gcc linking
 RUN apk update && \


### PR DESCRIPTION
It's a little early for this yet, but here it is. We can release it after migrating all the repos / CIs to rust >= 1.58.1.