### PR TITLE
Include git in images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,9 +79,10 @@ RUN cd build_workspace && \
 #
 FROM rust:1.60.0-alpine as base-optimizer
 
-# Being required for gcc linking
+# Being required for gcc linking.
+# Adding Git for usage within projects that use `git-fetch-with-cli = true`
 RUN apk update && \
-  apk add --no-cache musl-dev
+  apk add --no-cache musl-dev git
 
 # Setup Rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
This is useful for projects which use the Cargo config:

git-fetch-with-cli = true

This can be necessary for working with some private repositories as
dependencies.