### PR TITLE
Support incremental workspace optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Support incremental workspace optimizations ([#84])
+
 ## 0.12.6
 
 - Bump Rust to current stable v1.60.0.

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -27,6 +27,8 @@ TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
 # Optimize artifacts
 (
   cd "$TMPARTIFACTS"
+  INTERMEDIATE_SHAS="../artifacts/checksums_intermediate.txt"
+  OPTIMIZED_SHAS="../artifacts/checksums.txt"
 
   for WASM in ../target/wasm32-unknown-unknown/release/*.wasm; do
     BASENAME=$(basename "$WASM" .wasm)
@@ -34,7 +36,6 @@ TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
     OPTIMIZED_WASM=${NAME}.wasm
 
     INTERMEDIATE_SHA=$(sha256sum -- "$WASM" | sed 's,../target,target,g')
-    INTERMEDIATE_SHAS="../artifacts/checksums_intermediate.txt"
 
     SKIP_OPTIMIZATION=false
     if test -f "../artifacts/${OPTIMIZED_WASM}"; then
@@ -43,7 +44,6 @@ TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
         echo $?
       )
       OPTIMIZED_SHA=$(sha256sum -- "../artifacts/$OPTIMIZED_WASM" | sed 's,../artifacts/,,g')
-      OPTIMIZED_SHAS="../artifacts/checksums.txt"
       OPTIMIZED_CACHE_HIT=$(
         grep -Fxsq "$OPTIMIZED_SHA" "$OPTIMIZED_SHAS"
         echo $?

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -66,7 +66,7 @@ TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
 
       echo "Optimizing ${BASENAME}..."
       wasm-opt -Os "$WASM" -o "$OPTIMIZED_WASM"
-      echo "Moving wasm file..."
+      echo "Moving ${OPTIMIZED_WASM}..."
       mv "$OPTIMIZED_WASM" ../artifacts
     fi
   done

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -18,29 +18,38 @@ cargo --version
 rm -f target/wasm32-unknown-unknown/release/*.wasm
 
 # Build artifacts
-echo "Building artifacts in workspace ..."
+echo "Building artifacts in workspace..."
 /usr/local/bin/build_workspace
 
 mkdir -p artifacts
-echo "Creating intermediate hashes ..."
-sha256sum -- target/wasm32-unknown-unknown/release/*.wasm | tee artifacts/checksums_intermediate.txt
-
-echo "Optimizing artifacts in workspace ..."
+echo "Optimizing artifacts in workspace..."
 TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
 # Optimize artifacts
 (
   cd "$TMPARTIFACTS"
 
   for WASM in ../target/wasm32-unknown-unknown/release/*.wasm; do
-    NAME=$(basename "$WASM" .wasm)${SUFFIX}.wasm
-    echo "Optimizing $NAME ..."
-    wasm-opt -Os "$WASM" -o "$NAME"
+    BASENAME=$(basename "$WASM" .wasm)
+    NAME=${BASENAME}${SUFFIX}
+    FILENAME=${NAME}.wasm
+
+    SHA256=$(sha256sum -- "$WASM" | sed 's/..\/target/target/g')
+    INTERMEDIATES="../artifacts/checksums_intermediate.txt"
+    if grep -Fxq "$SHA256" "$INTERMEDIATES"; then
+      echo "$BASENAME unchanged. Skipping optimization."
+    else
+      grep -vs "$BASENAME" "$INTERMEDIATES" >tmp_shas && mv -f tmp_shas "$INTERMEDIATES"
+      echo "Creating intermediate hash for ${BASENAME}..."
+      echo "$SHA256" | tee -a "$INTERMEDIATES" >/dev/null
+      echo "Optimizing ${BASENAME}..."
+      wasm-opt -Os "$WASM" -o "$FILENAME"
+      echo "Moving wasm files..."
+      mv ./*.wasm ../artifacts
+    fi
   done
-  echo "Moving wasm files ..."
-  mv ./*.wasm ../artifacts
 )
 rm -rf "$TMPARTIFACTS"
-echo "Post-processing artifacts in workspace ..."
+echo "Post-processing artifacts in workspace..."
 (
   cd artifacts
   sha256sum -- *.wasm | tee checksums.txt

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -62,8 +62,8 @@ TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
       else
         echo "Creating intermediate hash for ${BASENAME}..."
       fi
+      echo "$INTERMEDIATE_SHA" >>"$INTERMEDIATE_SHAS"
 
-      echo "$INTERMEDIATE_SHA" | tee -a "$INTERMEDIATE_SHAS" >/dev/null
       echo "Optimizing ${BASENAME}..."
       wasm-opt -Os "$WASM" -o "$OPTIMIZED_WASM"
       echo "Moving wasm file..."

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -35,7 +35,7 @@ TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
 
     SHA256=$(sha256sum -- "$WASM" | sed 's/..\/target/target/g')
     INTERMEDIATES="../artifacts/checksums_intermediate.txt"
-    if grep -Fxq "$SHA256" "$INTERMEDIATES"; then
+    if grep -Fxq "$SHA256" "$INTERMEDIATES" && test -f "../artifacts/${FILENAME}"; then
       echo "$BASENAME unchanged. Skipping optimization."
     else
       grep -vs "$BASENAME" "$INTERMEDIATES" >tmp_shas && mv -f tmp_shas "$INTERMEDIATES"
@@ -43,8 +43,8 @@ TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
       echo "$SHA256" | tee -a "$INTERMEDIATES" >/dev/null
       echo "Optimizing ${BASENAME}..."
       wasm-opt -Os "$WASM" -o "$FILENAME"
-      echo "Moving wasm files..."
-      mv ./*.wasm ../artifacts
+      echo "Moving wasm file..."
+      mv "$FILENAME" ../artifacts
     fi
   done
 )

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -58,7 +58,7 @@ TMPARTIFACTS=$(mktemp -p "$(pwd)" -d artifacts.XXXXXX)
     else
       if test -f "$INTERMEDIATE_SHAS"; then
         echo "Updating intermediate hash for ${BASENAME}..."
-        grep -v "$BASENAME" "$INTERMEDIATE_SHAS" >tmp_shas && mv -f tmp_shas "$INTERMEDIATE_SHAS"
+        sed -ni "/$BASENAME/!p" "$INTERMEDIATE_SHAS"
       else
         echo "Creating intermediate hash for ${BASENAME}..."
       fi


### PR DESCRIPTION
The Rust compiler has superb support for [incremental builds](https://nnethercote.github.io/perf-book/compile-times.html#incremental-compilation) and other optimizations to keep down (re-)compilation times.

Unfortunately, `workspace-optimizer` will re-optimize WASM binaries even if they didn't change since the last run. In monorepos with many contracts this means a lot of pointless waiting, even on a fast machine.

This PR checks the intermediate SHA against the previous one, and only re-optimizes if it changed.

Tested in a monorepo with ~10 contracts:
- Fresh run from clean state -> optimizes all binaries
- Rerun again -> skip all optimizations, no changes detected
- Make a small change in one contract -> only re-optimizes that one, skips the rest

**Update:** also tested:
- Fresh run, then delete one optimized binary from `artifacts/`, then rerun again -> re-optimizes missing binary, skips the rest