### PR TITLE
Bump Rust to 1.68.0 with sparse protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Bump Rust to 1.68.0 with sparse protocol support
+
 ## [0.12.12] - 2023-03-06
 
 - Bump Rust to 1.67.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Bump Rust to 1.68.0 with sparse protocol support
+- Bump Rust to 1.68.0 [with sparse protocol support](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html)
 
 ## [0.12.12] - 2023-03-06
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ RUN cd build_workspace && \
 #
 FROM rust:1.68.0-alpine as base-optimizer
 
+# Download the crates.io index using the new sparse protocol to improve performance
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
 # Being required for gcc linking
 RUN apk update && \
   apk add --no-cache musl-dev
@@ -99,9 +102,6 @@ COPY --from=builder /usr/local/bin/wasm-opt /usr/local/bin
 # rust-optimizer
 #
 FROM base-optimizer as rust-optimizer
-
-# Download the crates.io index using the new sparse protocol to improve performance
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 # Use sccache. Users can override this variable to disable caching.
 COPY --from=builder /usr/local/bin/sccache /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67.1-alpine as targetarch
+FROM rust:1.68.0-alpine as targetarch
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
@@ -83,7 +83,7 @@ RUN cd build_workspace && \
 #
 # base-optimizer
 #
-FROM rust:1.67.1-alpine as base-optimizer
+FROM rust:1.68.0-alpine as base-optimizer
 
 # Being required for gcc linking
 RUN apk update && \
@@ -99,6 +99,9 @@ COPY --from=builder /usr/local/bin/wasm-opt /usr/local/bin
 # rust-optimizer
 #
 FROM base-optimizer as rust-optimizer
+
+# Download the crates.io index using the new sparse protocol to improve performance
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 # Use sccache. Users can override this variable to disable caching.
 COPY --from=builder /usr/local/bin/sccache /usr/local/bin


### PR DESCRIPTION
The new version of Rust added a feature that allows [switching the protocol](https://doc.rust-lang.org/cargo/reference/config.html#registriescrates-ioprotocol) used to fetch the index for `crates.io`.

The default implementation uses `git`, which downloads the entire GitHub repository with thousands of crates that aren't used during the build process. The new `sparse` protocol uses HTTPS instead to download only the dependencies defined in the `Cargo.toml` file.