### PR TITLE
feat: adding `llvm` and `clang` to base-optimizer for supporting contracts with FFI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 # Being required for gcc linking
 RUN apk update && \
-  apk add --no-cache musl-dev
+  apk add --no-cache musl-dev llvm clang
 
 # Setup Rust with Wasm support
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
## Problem

We have been working on a Wasm smart contract that might use [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) as a dependency. The secp256k1 functionalities in rust-bitcoin use FFI to some C++ code, thus require `llvm-ar` and `clang` binaries for compiling the Wasm smart contract as discussed [here](https://github.com/rust-bitcoin/rust-bitcoin/issues/930#issuecomment-1215538699). The final rust-optimizer image omits these binaries, thus cannot compile such Wasm smart contracts with FFI.

## This PR

This PR proposes a fix to this issue. It adds `clang` and `llvm` to the `base-optimizer` target, such that `rust-optimizer` and `workspace-optimizer` will inherit them and can compile Wasm smart contracts with FFI.