### PR TITLE
Use sccache consistently in rust-optimizer and workspace-optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump Rust to current stable v1.72.0.
 - Use builder tool `bob` for both single contract and workspace builds ([#134])
 - Use sccache consistently in rust-optimizer and workspace-optimizer
+- Upgrade sccache to 0.5.4
 
 ## [0.14.0] - 2023-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump Rust to current stable v1.72.0.
 - Use builder tool `bob` for both single contract and workspace builds ([#134])
+- Use sccache consistently in rust-optimizer and workspace-optimizer
 
 ## [0.14.0] - 2023-07-28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN cargo --version
 RUN wasm-opt --version
 
 # Download sccache and verify checksum
-ADD https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-$ARCH-unknown-linux-musl.tar.gz /tmp/sccache.tar.gz
-RUN sha256sum /tmp/sccache.tar.gz | egrep '(e5d03a9aa3b9fac7e490391bbe22d4f42c840d31ef9eaf127a03101930cbb7ca|90d91d21a767e3f558196dbd52395f6475c08de5c4951a4c8049575fa6894489)'
+ADD https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-$ARCH-unknown-linux-musl.tar.gz /tmp/sccache.tar.gz
+RUN sha256sum /tmp/sccache.tar.gz | egrep '(4bf3ce366aa02599019093584a5cbad4df783f8d6e3610548c2044daa595d40b|85f0cfe9b3150e461801cf7453763080fc3604e255587e2a4886e55bb93e6b09)'
 
 # Extract and install sccache
 RUN tar -xf /tmp/sccache.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,14 +105,14 @@ RUN rustup target add wasm32-unknown-unknown
 COPY --from=builder /usr/local/bin/bob /usr/local/bin
 COPY --from=builder /usr/local/bin/wasm-opt /usr/local/bin
 
+# Use sccache. Users can override this variable to disable caching.
+COPY --from=builder /usr/local/bin/sccache /usr/local/bin
+ENV RUSTC_WRAPPER=sccache
+
 #
 # rust-optimizer
 #
 FROM base-optimizer as rust-optimizer
-
-# Use sccache. Users can override this variable to disable caching.
-COPY --from=builder /usr/local/bin/sccache /usr/local/bin
-ENV RUSTC_WRAPPER=sccache
 
 # Assume we mount the source code in /code
 WORKDIR /code

--- a/optimize.sh
+++ b/optimize.sh
@@ -4,12 +4,16 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 
-export PATH=$PATH:/root/.cargo/bin
+export PATH="$PATH:/root/.cargo/bin"
 
 # Suffix for non-Intel built artifacts
 MACHINE=$(uname -m)
 SUFFIX=${MACHINE#x86_64}
 SUFFIX=${SUFFIX:+-$SUFFIX}
+
+# Debug toolchain and default Rust version
+rustup toolchain list
+cargo --version
 
 echo "Info: RUSTC_WRAPPER=$RUSTC_WRAPPER"
 

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -11,8 +11,11 @@ MACHINE=$(uname -m)
 SUFFIX=${MACHINE#x86_64}
 SUFFIX=${SUFFIX:+-$SUFFIX}
 
+# Debug toolchain and default Rust version
 rustup toolchain list
 cargo --version
+
+echo "Info: RUSTC_WRAPPER=$RUSTC_WRAPPER"
 
 # Delete already built artifacts
 rm -f target/wasm32-unknown-unknown/release/*.wasm

--- a/optimize_workspace.sh
+++ b/optimize_workspace.sh
@@ -17,6 +17,9 @@ cargo --version
 
 echo "Info: RUSTC_WRAPPER=$RUSTC_WRAPPER"
 
+echo "Info: sccache stats before build"
+sccache -s
+
 # Delete already built artifacts
 rm -f target/wasm32-unknown-unknown/release/*.wasm
 
@@ -81,5 +84,8 @@ echo "Post-processing artifacts in workspace..."
   cd artifacts
   sha256sum -- *.wasm | tee checksums.txt
 )
+
+echo "Info: sccache stats after build"
+sccache -s
 
 echo "done"


### PR DESCRIPTION
Part of #135 with the long term goal to only require one image that dynamically switches between the single contract and workspace case