### PR TITLE
Further unify docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,8 @@ jobs:
             sudo apt install -y docker-ce docker-ce-cli containerd.io
       - checkout
       - run:
-          name: Build rust-optimizer
-          command: make build-rust-optimizer-x86_64
-      - run:
-          name: Build workspace-optimizer
-          command: make build-workspace-optimizer-x86_64
+          name: Build
+          command: make build-x86_64
       - test_images
 
   build-arm64:
@@ -87,11 +84,8 @@ jobs:
             sudo apt install -y docker-ce docker-ce-cli containerd.io
       - checkout
       - run:
-          name: Build rust-optimizer
-          command: make build-rust-optimizer-arm64
-      - run:
-          name: Build workspace-optimizer
-          command: make build-workspace-optimizer-arm64
+          name: Build
+          command: make build-arm64
       - test_images
 
   lint-scripts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,9 @@ RUN cd bob_the_builder && \
   mv target/release/bob /usr/local/bin
 
 #
-# base-optimizer
+# rust-optimizer target
 #
-FROM rust:1.73.0-alpine as base-optimizer
+FROM rust:1.73.0-alpine as rust-optimizer
 
 # Download the crates.io index using the new sparse protocol to improve performance
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
@@ -95,20 +95,6 @@ COPY --from=builder /usr/local/bin/optimize.sh /usr/local/bin
 
 # Assume we mount the source code in /code
 WORKDIR /code
-
-#
-# rust-optimizer
-#
-FROM base-optimizer as rust-optimizer
-
-ENTRYPOINT ["optimize.sh"]
-# Default argument when none is provided
-CMD ["."]
-
-#
-# workspace-optimizer
-#
-FROM base-optimizer as workspace-optimizer
 
 ENTRYPOINT ["optimize.sh"]
 # Default argument when none is provided

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,36 @@
-.PHONY: build-rust-optimizer build-workspace-optimizer build create-rust-optimizer-multi use-rust-optimizer-multi publish-rust-optimizer-multi publish-workspace-optimizer-multi publish-multi
-
-DOCKER_NAME_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
-DOCKER_NAME_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
+# Docker names (DN) for the images
+DN_OPTIMIZER := "cosmwasm/optimizer"
+DN_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
+DN_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
 DOCKER_TAG := 0.14.0
 
 # Native arch
 BUILDARCH := $(shell uname -m)
 
-# Build the native CPU arch images and publish them. Rust alpine images support the linux/amd64 and linux/arm64/v8 architectures.
-build: build-rust-optimizer build-workspace-optimizer
+# Build the native CPU arch images
+.PHONY: build
+build: build-$(BUILDARCH)
 
-build-rust-optimizer-x86_64:
-	docker buildx build --pull --platform linux/amd64 -t $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
-
-build-rust-optimizer-arm64:
-	docker buildx build --pull --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER)-arm64:$(DOCKER_TAG) --target rust-optimizer --load .
-
-build-workspace-optimizer-x86_64:
-	docker buildx build --pull --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
-
-build-workspace-optimizer-arm64:
-	docker buildx build --pull --platform linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER)-arm64:$(DOCKER_TAG) --target rust-optimizer --load .
-
-# Build only the native version by default
-build-rust-optimizer: build-rust-optimizer-$(BUILDARCH)
-
-# Build only the native version by default
-build-workspace-optimizer: build-workspace-optimizer-$(BUILDARCH)
-
+.PHONY: build-x86_64
 build-x86_64:
-	make build-rust-optimizer-x86_64
-	make build-workspace-optimizer-x86_64
+	docker buildx build --pull --platform linux/amd64 -t $(DN_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
+	docker tag $(DN_OPTIMIZER):$(DOCKER_TAG) $(DN_RUST_OPTIMIZER):$(DOCKER_TAG)
+	docker tag $(DN_OPTIMIZER):$(DOCKER_TAG) $(DN_WORKSPACE_OPTIMIZER):$(DOCKER_TAG)
 
+.PHONY: build-arm64
 build-arm64:
-	make build-rust-optimizer-arm64
-	make build-workspace-optimizer-arm64
+	docker buildx build --pull --platform linux/arm64/v8 -t $(DN_OPTIMIZER)-arm64:$(DOCKER_TAG) --target rust-optimizer --load .
+	docker tag $(DN_OPTIMIZER)-arm64:$(DOCKER_TAG) $(DN_RUST_OPTIMIZER)-arm64:$(DOCKER_TAG)
+	docker tag $(DN_OPTIMIZER)-arm64:$(DOCKER_TAG) $(DN_WORKSPACE_OPTIMIZER)-arm64:$(DOCKER_TAG)
 
+.PHONY: publish-x86_64
 publish-x86_64: build-x86_64
-	docker push $(DOCKER_NAME_RUST_OPTIMIZER):$(DOCKER_TAG)
-	docker push $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG)
+	docker push $(DN_OPTIMIZER):$(DOCKER_TAG)
+	docker push $(DN_RUST_OPTIMIZER):$(DOCKER_TAG)
+	docker push $(DN_WORKSPACE_OPTIMIZER):$(DOCKER_TAG)
 
+.PHONY: publish-arm64
 publish-arm64: build-arm64
-	docker push $(DOCKER_NAME_RUST_OPTIMIZER)-arm64:$(DOCKER_TAG)
-	docker push $(DOCKER_NAME_WORKSPACE_OPTIMIZER)-arm64:$(DOCKER_TAG)
+	docker push $(DN_OPTIMIZER)-arm64:$(DOCKER_TAG)
+	docker push $(DN_RUST_OPTIMIZER)-arm64:$(DOCKER_TAG)
+	docker push $(DN_WORKSPACE_OPTIMIZER)-arm64:$(DOCKER_TAG)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DN_OPTIMIZER := "cosmwasm/optimizer"
 DN_RUST_OPTIMIZER := "cosmwasm/rust-optimizer"
 DN_WORKSPACE_OPTIMIZER := "cosmwasm/workspace-optimizer"
-DOCKER_TAG := 0.14.0
+DOCKER_TAG := 0.15.0-beta.1
 
 # Native arch
 BUILDARCH := $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ build-rust-optimizer-arm64:
 	docker buildx build --pull --platform linux/arm64/v8 -t $(DOCKER_NAME_RUST_OPTIMIZER)-arm64:$(DOCKER_TAG) --target rust-optimizer --load .
 
 build-workspace-optimizer-x86_64:
-	docker buildx build --pull --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target workspace-optimizer --load .
+	docker buildx build --pull --platform linux/amd64 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER):$(DOCKER_TAG) --target rust-optimizer --load .
 
 build-workspace-optimizer-arm64:
-	docker buildx build --pull --platform linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER)-arm64:$(DOCKER_TAG) --target workspace-optimizer --load .
+	docker buildx build --pull --platform linux/arm64/v8 -t $(DOCKER_NAME_WORKSPACE_OPTIMIZER)-arm64:$(DOCKER_TAG) --target rust-optimizer --load .
 
 # Build only the native version by default
 build-rust-optimizer: build-rust-optimizer-$(BUILDARCH)

--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ source code we can avoid those sort of problems.
 ## Development
 
 Take a look at the [Makefile](https://github.com/CosmWasm/rust-optimizer/blob/master/Makefile)
-You can edit the Dockerfile (in a fork), and run `make build` to compile it,
-and `make run` to test it (requires the `CODE` env var to be set)
+You can edit the Dockerfile (in a fork), and run `make build` to compile it.
 
 ## Notice
 


### PR DESCRIPTION
Follow-up of #135

With this change, `make build-x86_64` gets us
- cosmwasm/optimizer:0.15.0-beta.1
- cosmwasm/rust-optimizer:0.15.0-beta.1
- cosmwasm/workspace-optimizer:0.15.0-beta.1

and `make build-arm64` builds

- cosmwasm/optimizer-arm64:0.15.0-beta.1
- cosmwasm/rust-optimizer-arm64:0.15.0-beta.1
- cosmwasm/workspace-optimizer-arm64:0.15.0-beta.1

The `docker tag`s of the old names are for migration reasons and can be removed once cosmwasm/optimizer is working well and is established in docs and example repos.